### PR TITLE
feat(ubuntu): add support 20.04-ESM

### DIFF
--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -52,16 +52,16 @@ var (
 		"oracular": "24.10",
 		// ESM versions:
 		"precise/esm": "12.04-ESM",
- 		"trusty/esm":  "14.04-ESM",
+		"trusty/esm":  "14.04-ESM",
 		// Possible multiple values for one release:
- 		// (release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky")
- 		// cf. https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867
+		// (release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky")
+		// cf. https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867
 		"esm-infra/xenial": "16.04-ESM",
-		"esm-apps/xenial": "16.04-ESM",
+		"esm-apps/xenial":  "16.04-ESM",
 		"esm-infra/bionic": "18.04-ESM",
 		"esm-apps/bionic":  "18.04-ESM",
- 		"esm-infra/focal":  "20.04-ESM",
- 		"esm-apps/focal":   "20.04-ESM",
+		"esm-infra/focal":  "20.04-ESM",
+		"esm-apps/focal":   "20.04-ESM",
 	}
 
 	source = types.DataSource{

--- a/pkg/vulnsrc/ubuntu/ubuntu.go
+++ b/pkg/vulnsrc/ubuntu/ubuntu.go
@@ -51,10 +51,17 @@ var (
 		"noble":    "24.04",
 		"oracular": "24.10",
 		// ESM versions:
-		"precise/esm":      "12.04-ESM",
-		"trusty/esm":       "14.04-ESM",
+		"precise/esm": "12.04-ESM",
+ 		"trusty/esm":  "14.04-ESM",
+		// Possible multiple values for one release:
+ 		// (release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky")
+ 		// cf. https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867
 		"esm-infra/xenial": "16.04-ESM",
+		"esm-apps/xenial": "16.04-ESM",
 		"esm-infra/bionic": "18.04-ESM",
+		"esm-apps/bionic":  "18.04-ESM",
+ 		"esm-infra/focal":  "20.04-ESM",
+ 		"esm-apps/focal":   "20.04-ESM",
 	}
 
 	source = types.DataSource{


### PR DESCRIPTION
Ubutnu now supports 20.04 only for Ubuntu pro (ESM). So we need to add advisories for 20.04-ESM.

New name for 20.04-ESM is esm-apps/focal:
(release_list="trusty trusty/esm xenial esm-infra/xenial esm-apps/xenial bionic esm-infra/bionic esm-apps/bionic focal esm-apps/focal jammy esm-apps/jammy noble oracular plucky" took from https://wiki.ubuntu.com/SecurityTeam/BuildEnvironment#line867

This PR also adds missed values for bionic and xenial (see link)

esm-apps/focal
esm-apps/bionic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded support for additional Ubuntu Extended Security Maintenance (ESM) release variants, including "xenial," "bionic," and "focal" for both "esm-infra" and "esm-apps".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->